### PR TITLE
Require python 3.9.0, not 3.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(name='ueimporter',
       },
       setup_requires=['pytest-runner'],
       tests_require=['pytest'],
-      python_requires='>=3.10.0',
+      python_requires='>=3.9.0',
       )

--- a/ueimporter/main.py
+++ b/ueimporter/main.py
@@ -237,7 +237,7 @@ def create_config(args, logger):
     if not source_release_zip_path.is_dir():
         logger.log_error(
             f'Error: Failed to find release zip package'
-            ' {source_release_zip_path}')
+            f' {source_release_zip_path}')
         sys.exit(1)
 
     return Config(git_repo,


### PR DESCRIPTION
It's likely enough, and it seems to work on Ubuntu where 3.9.0 is
the default.