### PR TITLE
Use git rev-list to resolve commit tag refers to

### DIFF
--- a/ueimporter/git.py
+++ b/ueimporter/git.py
@@ -91,8 +91,8 @@ class Repo:
     def to_repo_path(self, path):
         return self.repo_root.joinpath(path)
 
-    def rev_parse(self, ref, logger):
-        return self.run_cmd(['rev-parse', ref], logger).rstrip('\r\n')
+    def rev_list(self, ref, logger):
+        return self.run_cmd(['rev-list', '-n', '1', ref], logger).rstrip('\r\n')
 
     def diff(self, from_ref, to_ref, logger):
         arguments = [

--- a/ueimporter/main.py
+++ b/ueimporter/main.py
@@ -103,9 +103,9 @@ def read_change_jobs(config, logger):
     try:
         logger.log('Resolving git hashes of release tags')
         logger.indent()
-        from_git_hash = config.git_repo.rev_parse(
+        from_git_hash = config.git_repo.rev_list(
             config.from_release_tag, logger)
-        to_git_hash = config.git_repo.rev_parse(config.to_release_tag, logger)
+        to_git_hash = config.git_repo.rev_list(config.to_release_tag, logger)
         logger.log(f'{config.from_release_tag} <=> {from_git_hash}')
         logger.log(f'{config.to_release_tag} <=> {to_git_hash}')
         logger.deindent()
@@ -217,12 +217,12 @@ def create_config(args, logger):
             f'Error: Please specify a git release tag with --to-release-tag')
         sys.exit(1)
 
-    if not git_repo.rev_parse(from_release_tag, logger):
+    if not git_repo.rev_list(from_release_tag, logger):
         logger.log_error(
             f'Error: Failed to find release tag named {from_release_tag}')
         sys.exit(1)
 
-    if not git_repo.rev_parse(args.to_release_tag, logger):
+    if not git_repo.rev_list(args.to_release_tag, logger):
         logger.log_error(
             f'Error: Failed to find release tag named {args.to_release_tag}')
         sys.exit(1)


### PR DESCRIPTION
rev-parse will give you the hash of the tag object itself. This worked but all the following git commands we sent this commit to had to resolve the tag object reference hash to a commit hash each time.